### PR TITLE
Use newest version GVim 8.1.0

### DIFF
--- a/manifests/gvim/gvim.yaml
+++ b/manifests/gvim/gvim.yaml
@@ -1,8 +1,8 @@
 id: gvim
 name: Gvim
-version: 8.0.586
+version: 8.1.0
 home: https://nluug.nl/
 installMethod: NSIS
 installers:
-- location: https://ftp.nluug.nl/pub/vim/pc/gvim80-586.exe
-  sha256: ce2aced36a2df7039941225dc492aebe6f7c77fc9d876c5d26c472f16fbc275e
+- location: https://ftp.nluug.nl/pub/vim/pc/gvim81.exe
+  sha256: 0f613497e909f7140061a0afa309b5e11a9ff9036b1deb01ce708987fdb708b9


### PR DESCRIPTION
Version 8.1.0 is half a year old, but it is for now the latest available from the official repo.

GVim 8.0.586 which is currently in the repo dates back from 2016.