### PR TITLE
LibreOffice passive install support.

### DIFF
--- a/manifests/libreoffice/libreoffice.yaml
+++ b/manifests/libreoffice/libreoffice.yaml
@@ -2,10 +2,14 @@ id: libreoffice
 name: LibreOffice
 version: 6.2.0.3
 home: https://www.libreoffice.org/
+repo: https://cgit.freedesktop.org/libreoffice
 installMethod: MSI
 installers:
+args:
+  passive: /passive /norestart ALLUSERS=1 CREATEDESKTOPLINK=1 REGISTER_ALL_MSO_TYPES=0 REGISTER_NO_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 QUICKSTART=0 ADDLOCAL=ALL
 - location: https://download.documentfoundation.org/libreoffice/stable/6.2.0/win/x86/LibreOffice_6.2.0_Win_x86.msi
   sha256: 71ceed80aa77137cf60264652d435930bdb1d4f0c8ee5d7418885ad6ac795d67
+  architecture: x86
 - location: https://download.documentfoundation.org/libreoffice/stable/6.2.0/win/x86_64/LibreOffice_6.2.0_Win_x64.msi
   sha256: 83028ca0db1a87abb304d77524b51d42be734e0e74f22012bdb7f750d8328996
   architecture: x64

--- a/manifests/libreoffice/libreoffice.yaml
+++ b/manifests/libreoffice/libreoffice.yaml
@@ -7,6 +7,7 @@ license: Mozilla Public License 2.0
 installMethod: MSI
 args:
   passive: REGISTER_NO_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 ADDLOCAL=ALL
+  silent: REGISTER_NO_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 ADDLOCAL=ALL
 installers:
 - location: https://download.documentfoundation.org/libreoffice/stable/6.2.0/win/x86/LibreOffice_6.2.0_Win_x86.msi
   sha256: 71ceed80aa77137cf60264652d435930bdb1d4f0c8ee5d7418885ad6ac795d67

--- a/manifests/libreoffice/libreoffice.yaml
+++ b/manifests/libreoffice/libreoffice.yaml
@@ -3,13 +3,15 @@ name: LibreOffice
 version: 6.2.0.3
 home: https://www.libreoffice.org/
 repo: https://cgit.freedesktop.org/libreoffice
+license: Mozilla Public License 2.0
 installMethod: MSI
-installers:
 args:
-  passive: /passive /norestart ALLUSERS=1 CREATEDESKTOPLINK=1 REGISTER_ALL_MSO_TYPES=0 REGISTER_NO_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 QUICKSTART=0 ADDLOCAL=ALL
+  passive: REGISTER_NO_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 ADDLOCAL=ALL
+installers:
 - location: https://download.documentfoundation.org/libreoffice/stable/6.2.0/win/x86/LibreOffice_6.2.0_Win_x86.msi
   sha256: 71ceed80aa77137cf60264652d435930bdb1d4f0c8ee5d7418885ad6ac795d67
-  architecture: x86
+  minWindowsVersion: 6.1
 - location: https://download.documentfoundation.org/libreoffice/stable/6.2.0/win/x86_64/LibreOffice_6.2.0_Win_x64.msi
   sha256: 83028ca0db1a87abb304d77524b51d42be734e0e74f22012bdb7f750d8328996
   architecture: x64
+  minWindowsVersion: 6.1


### PR DESCRIPTION
I added a `passive` option in the `libreoffice` YAML manifest with some sane defaults. Also, I added a link to the official source code repository. These install parameters several times on a 64 bit Windows 10 machine without any issues.