### PR TITLE
fix: keybase

### DIFF
--- a/manifests/keybase/keybase.yaml
+++ b/manifests/keybase/keybase.yaml
@@ -1,9 +1,9 @@
 id: keybase
 name: Keybase
-version: 2.1.0.6
 home: https://keybase.io/
 repo: https://github.com/keybase/client/
 license: BSD 3-Clause "New" or "Revised" License
-installMethod: Wix
+installMethod: MSI
 installers:
-- location: https://prerelease.keybase.io/keybase_setup_386.exe
+- location: https://prerelease.keybase.io/keybase_setup_amd64.msi
+  architecture: x64


### PR DESCRIPTION
Keybase has changed over to a msi installer and currently only provides files for x64 architectures.  
As the url always points to the latest file, defining a version is not possible.

Supersedes #3967 