### PR TITLE
update to R 3.6.1

### DIFF
--- a/manifests/r/r.yaml
+++ b/manifests/r/r.yaml
@@ -1,8 +1,8 @@
 id: r
 name: R for Windows
-version: 3.5.3.26217
+version: 3.6.1
 home: https://www.r-project.org/
 installMethod: Inno
 installers:
-- location: https://cloud.r-project.org/bin/windows/base/R-3.5.3-win.exe
-  sha256: c9df8192e49823fbeb5ac71a21ec244084bcd9ae178603245292735cf4896893
+- location: https://cloud.r-project.org/bin/windows/base/old/3.6.1/R-3.6.1-win.exe
+  sha256: 8019bdc376ed22c657b2441d15f2b9c6f9507fbffe896534fc2d364021f1c930


### PR DESCRIPTION
Pointing to the "old" source on the CRAN website means the referenced R version will be available even when a new version is released