### PR TITLE
R build tools

### DIFF
--- a/manifests/rtools/rtools.yaml
+++ b/manifests/rtools/rtools.yaml
@@ -1,0 +1,8 @@
+id: rtools
+name: RTools
+version: 3.5.0.4
+home: https://cran.r-project.org/bin/windows/Rtools/
+installMethod: Inno
+installers:
+  - location: https://cloud.r-project.org/bin/windows/Rtools/Rtools35.exe
+    sha256: 18fd63bb9c903e1f9bfce5c9a2600bd24213295760592dbc130b73a61e9d9414


### PR DESCRIPTION
These build tools are used to build R, or to build R packages from source when binaries are unavailable.