### PR TITLE
Bump LibreOffice to 6.4.2, Fix Broken DL

### DIFF
--- a/manifests/libreoffice/libreoffice.yaml
+++ b/manifests/libreoffice/libreoffice.yaml
@@ -1,6 +1,6 @@
 id: libreoffice
 name: LibreOffice
-version: 6.4.0.3
+version: 6.4.2
 home: https://www.libreoffice.org/
 repo: https://cgit.freedesktop.org/libreoffice
 license: Mozilla Public License 2.0
@@ -9,8 +9,8 @@ args:
   passive: REGISTER_NO_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 ADDLOCAL=ALL
   silent: REGISTER_NO_MSO_TYPES=1 ISCHECKFORPRODUCTUPDATES=0 ADDLOCAL=ALL
 installers:
-- location: https://download.documentfoundation.org/libreoffice/stable/6.4.0/win/x86/LibreOffice_6.4.0_Win_x86.msi
-  sha256: 357b9dee3c762e2ecece604f5e7512181dc1f6a0b5169b550037d8af935c5f87
-- location: https://download.documentfoundation.org/libreoffice/stable/6.4.0/win/x86_64/LibreOffice_6.4.0_Win_x64.msi
-  sha256: 4fd83acacebdaed54003804a7518224e205542d17bd517cb8b87fc2adb5e94b6
+- location: https://download.documentfoundation.org/libreoffice/stable/6.4.2/win/x86/LibreOffice_6.4.2_Win_x86.msi
+  sha256: ee149db673fcbe6fb311703a96c29dfd7e1901381d50d992274c909484a061a0
+- location: https://download.documentfoundation.org/libreoffice/stable/6.4.2/win/x86_64/LibreOffice_6.4.2_Win_x64.msi
+  sha256: 853bf1e8b46b849a57d4643dbde8451280d7ff8140e68af355acc868e3a00bd1
   architecture: x64


### PR DESCRIPTION
The current version of the `libreoffice` manifest points to an invalid location and this causes installation attempts to fail. I have updated the the URL in the manifest and bumped the LibreOffice version number to 6.4.2, which is the most recent stable version available.